### PR TITLE
Update ghe-storage-test.sh to use -TreatWarningAsErrors param in the cmdlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository to allow partners to perform a storage check against GitHub Ente
 
 Currently covered:
 - Actions Artifacts and Logs
+- Direct download links from the storage, used for Artifact Cache
 
 Currently not covered:
-- Direct download links from the storage, used for Artifact Cache
 - Packages
 
 ## Permissions used

--- a/ghe-storage-test.sh
+++ b/ghe-storage-test.sh
@@ -68,7 +68,7 @@ else
     echo -e "${RED}Storage provider must be specified with '-p' parameter${NC}"
     exit 1
   fi
-  command="Test-StorageConnection -OverrideBlobProvider $provider -OverrideConnectionString '$connection_string'"
+  command="Test-StorageConnection -OverrideBlobProvider $provider -OverrideConnectionString '$connection_string' -TreatWarningAsErrors"
 fi
 
 docker_params+=("--mount" "type=tmpfs,destination=/home/actions/.actions-dev")


### PR DESCRIPTION
The [TestStorageConnectionCmdlet](https://github.com/github/actions-dotnet/blob/main/Vssf/SdkTools/PowerShell/Cmdlets/TestStorageConnectionCmdlet.cs) has been updated to use "TreatWarningAsErrors" parameter. The parameter, when set, will escalate warnings to errors.

**THIS IS RELEVANT FOR GHES 3.5**