### PR TITLE
Backward compatibility: TreatWarningAsErrors only when available

### DIFF
--- a/ghe-storage-test.sh
+++ b/ghe-storage-test.sh
@@ -105,9 +105,9 @@ if [[ -z "$command" ]]; then
   docker_run "$command"
 else
   echo -e "${GREEN}Running storage tests...${NC}"
-  version_check_command="help Test-StorageConnection  | grep 'TreatWarningAsErrors'"
-  version_check=$(docker_run "$version_check_command")
-  if [[ ! -z "$version_check" ]]; then
+  check_warning_command="help Test-StorageConnection  | grep 'TreatWarningAsErrors'"
+  warning_check=$(docker_run "$check_warning_command")
+  if [[ ! -z "$warning_check" ]]; then
     command="${command} -TreatWarningAsErrors"
   fi
   # sed commands make the LightRail output more readable.


### PR DESCRIPTION
The previous PR https://github.com/github-technology-partners/enterprise-storage-check/pull/2 introduced the parameter `TreatWarningAsErrors` in the `ghe-storage-test.sh` script, which is applicable only for GHES 3.5 and above. 

On older versions, the following error is seen: `Test-StorageConnection: A parameter cannot be found that matches parameter name 'TreatWarningAsErrors'`

To maintain backward compatibility with previous GHES version, this PR introduces a check to first test if the parameter is available in the command present in the given GHES image before using it.