### PR TITLE
OIDC update for doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently covered:
 
 Currently not covered:
 - Packages
+- OIDC authentication based storage check
 
 This test is for checking compatibility only, and will not run any scale testing.
 


### PR DESCRIPTION
## Description

In GHES 3.8, OIDC authentication is being introduced as an option for storage connection using which (if technology partners want to test storage check with OIDC) this storage check will not be testable without a GHES instance running. It can still be tested with existing credential based authentication basically how it is currently being tested.

This PR calls out the unavailability of OIDC authentication based storage check in the docs.
